### PR TITLE
Update monaco-editor plugin and fix 404 error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "start-server-and-test": "^1.14.0",
         "typescript": "^4.7.3",
         "vite": "^2.9.5",
-        "vite-plugin-monaco-editor": "^1.0.10",
+        "vite-plugin-monaco-editor": "github:evermake/vite-plugin-monaco-editor",
         "vitest": "^0.9.3",
         "vue-tsc": "^0.37.3"
       }
@@ -4764,9 +4764,9 @@
       "dev": true
     },
     "node_modules/monaco-editor": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.29.1.tgz",
-      "integrity": "sha512-rguaEG/zrPQSaKzQB7IfX/PpNa0qxF1FY8ZXRkN4WIl8qZdTQRSRJCtRto7IMcSgrU6H53RXI+fTcywOBC4aVw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
+      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw==",
       "dev": true,
       "peer": true
     },
@@ -6072,12 +6072,12 @@
       }
     },
     "node_modules/vite-plugin-monaco-editor": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.0.10.tgz",
-      "integrity": "sha512-7yTAFIE0SefjCmfnjrvXOl53wkxeSASc/ZIcB5tZeEK3vAmHhveV8y3f90Vp8b+PYdbUipjqf91mbFbSENkpcw==",
+      "version": "1.1.0.beta1",
+      "resolved": "git+ssh://git@github.com/evermake/vite-plugin-monaco-editor.git#c6150d9934e6d6f8b2279ea3175b9a542d5abcde",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "monaco-editor": "0.29.x"
+        "monaco-editor": "0.33.x"
       }
     },
     "node_modules/vitest": {
@@ -9879,9 +9879,9 @@
       "dev": true
     },
     "monaco-editor": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.29.1.tgz",
-      "integrity": "sha512-rguaEG/zrPQSaKzQB7IfX/PpNa0qxF1FY8ZXRkN4WIl8qZdTQRSRJCtRto7IMcSgrU6H53RXI+fTcywOBC4aVw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
+      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw==",
       "dev": true,
       "peer": true
     },
@@ -10802,10 +10802,9 @@
       }
     },
     "vite-plugin-monaco-editor": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.0.10.tgz",
-      "integrity": "sha512-7yTAFIE0SefjCmfnjrvXOl53wkxeSASc/ZIcB5tZeEK3vAmHhveV8y3f90Vp8b+PYdbUipjqf91mbFbSENkpcw==",
+      "version": "git+ssh://git@github.com/evermake/vite-plugin-monaco-editor.git#c6150d9934e6d6f8b2279ea3175b9a542d5abcde",
       "dev": true,
+      "from": "vite-plugin-monaco-editor@evermake/vite-plugin-monaco-editor",
       "requires": {}
     },
     "vitest": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start-server-and-test": "^1.14.0",
     "typescript": "^4.7.3",
     "vite": "^2.9.5",
-    "vite-plugin-monaco-editor": "^1.0.10",
+    "vite-plugin-monaco-editor": "github:evermake/vite-plugin-monaco-editor",
     "vitest": "^0.9.3",
     "vue-tsc": "^0.37.3"
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,13 @@ import GlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill"
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue(), vueJsx(), monacoEditorPlugin()],
+  plugins: [
+    vue(),
+    vueJsx(),
+    monacoEditorPlugin({
+      publicBaseUrl: process.env.VITE_BASE_URL || "/",
+    }),
+  ],
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
- `vite-plugin-monaco-editor` was replaced with evermake's fork
- specify `publicBaseUrl` in vite-plugin-monaco-editor in order to fix 404 error