### PR TITLE
Controller refactoring, languages sample code plugin, dynamic debounceTime

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,4 +22,5 @@ module.exports = {
     "prettier/prettier": "error",
     "no-undef": 0,
   },
+  ignorePatterns: ["src/**/sample.code.*"],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@rushstack/eslint-patch": "^1.1.3",
         "@types/babel__traverse": "^7.17.1",
         "@types/jsdom": "^16.2.14",
-        "@types/node": "^16.11.40",
+        "@types/node": "^16.11.41",
         "@vitejs/plugin-vue": "^2.3.3",
         "@vitejs/plugin-vue-jsx": "^1.3.10",
         "@vue/eslint-config-prettier": "^7.0.0",
@@ -910,9 +910,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.40.tgz",
-      "integrity": "sha512-7bOWglXUO6f21NG3YDI7hIpeMX3M59GG+DzZuzX2EkFKYUnRoxq3EOg4R0KNv2hxryY9M3UUqG5akwwsifrukw==",
+      "version": "16.11.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+      "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
       "dev": true
     },
     "node_modules/@types/parse5": {
@@ -7227,9 +7227,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.40.tgz",
-      "integrity": "sha512-7bOWglXUO6f21NG3YDI7hIpeMX3M59GG+DzZuzX2EkFKYUnRoxq3EOg4R0KNv2hxryY9M3UUqG5akwwsifrukw==",
+      "version": "16.11.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+      "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
       "dev": true
     },
     "@types/parse5": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@rushstack/eslint-patch": "^1.1.3",
     "@types/babel__traverse": "^7.17.1",
     "@types/jsdom": "^16.2.14",
-    "@types/node": "^16.11.40",
+    "@types/node": "^16.11.41",
     "@vitejs/plugin-vue": "^2.3.3",
     "@vitejs/plugin-vue-jsx": "^1.3.10",
     "@vue/eslint-config-prettier": "^7.0.0",

--- a/plugins/languagesSampleCodePlugin.ts
+++ b/plugins/languagesSampleCodePlugin.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from "rollup"
+import fs from "fs"
+
+/**
+ * Rollup plugin that includes sample codes for each language in the bundle.
+ */
+export default function languagesSampleCodePlugin(): Plugin {
+  return {
+    name: "rollup-plugin-syntax-visualizer-languages-sample-code",
+    resolveId(source) {
+      if (isSampleCode(source)) {
+        return source
+      } else if (source.endsWith("?worker")) {
+        return source.slice(0, -7)
+      }
+      return null
+    },
+    async load(id) {
+      if (isSampleCode(id)) {
+        const fileContent = fs.readFileSync(id, "utf8")
+        return `export default ${JSON.stringify(fileContent)}`
+      }
+      return null
+    },
+  }
+}
+
+function isSampleCode(id: string): boolean {
+  return Boolean(id.match(/\/sample\.code\.(\w+)$/))
+}

--- a/src/components/TheTabs.vue
+++ b/src/components/TheTabs.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { nextTick, ref } from "vue"
 import AppTab from "@/components/AppTab.vue"
 import CodeEditor from "@/components/editor/CodeEditor.vue"
 import AbstractSyntaxTree from "@/components/ast/AbstractSyntaxTree.vue"
@@ -9,14 +8,7 @@ import { useParsingController } from "@/core/controller"
 
 const { codeEditorVariant, astVariant } = useSettingsStore()
 
-// TODO: refactor
-// Set initial debounce time to zero to parse AST for the initial code immediately
-const debounceTime = ref(0)
-nextTick(() => {
-  debounceTime.value = 300
-})
-
-const { code, ast } = useParsingController(debounceTime)
+const { code, ast } = useParsingController()
 </script>
 
 <template>

--- a/src/core/controller.ts
+++ b/src/core/controller.ts
@@ -1,25 +1,30 @@
 import type { Ref } from "vue"
-import { ref, watch } from "vue"
-import { watchDebounced } from "@vueuse/core"
+import { computed, ref, watch } from "vue"
+import { watchDebounced, watchThrottled } from "@vueuse/core"
+import { storeToRefs } from "pinia"
 import { useSettingsStore } from "@/stores/settings"
-import languages from "@/core/languages"
+import languages, { loadLanguageSampleCode } from "@/core/languages"
 import type { AST, ParseError } from "@/core/types"
 
-export function useParsingController(debounceTime: Ref<number> | number) {
-  const { parse, sampleCode } = useLanguageSettings()
-  const code = ref<string>(sampleCode)
+export function useParsingController() {
+  const { languageId, parserName } = storeToRefs(useSettingsStore())
+  const parse = computed(
+    () => languages[languageId.value].parsers[parserName.value].parse
+  )
+  const code = useCode()
+  const debounceTime = useDebounceTimeBasedOnCode(code)
   const ast = ref<AST>()
   const error = ref<ParseError>()
-  const isActual = ref<boolean>(false)
+  const isParsing = ref<boolean>(false)
 
   watch(code, () => {
-    if (isActual.value) isActual.value = false
+    isParsing.value = false
   })
 
   watchDebounced(
     code,
     () => {
-      const result = parse(code.value)
+      const result = parse.value(code.value)
 
       if (result.success) {
         ast.value = result.ast
@@ -28,22 +33,63 @@ export function useParsingController(debounceTime: Ref<number> | number) {
         error.value = result.error
       }
 
-      isActual.value = true
+      isParsing.value = true
     },
     { debounce: debounceTime, immediate: true }
   )
 
-  return { code, ast, error, isActual }
+  return { code, ast, error, isParsing }
 }
 
-function useLanguageSettings() {
-  const { languageId, parserName } = useSettingsStore()
+function useCode() {
+  const code = ref("")
+  const { languageId } = storeToRefs(useSettingsStore())
 
-  const language = languages[languageId]
-  const parse = language.parsers[parserName].parse
-  const sampleCodeRaw = language.sampleCode
-  const sampleCode =
-    typeof sampleCodeRaw === "string" ? sampleCodeRaw : sampleCodeRaw.join("\n")
+  // Set the code to a sample code when the language changes
+  watch(
+    [code, languageId],
+    async ([newCode, newLanguageId], [oldCode, oldLanguageId]) => {
+      const wasCodeUpdated = newCode !== oldCode && oldCode !== undefined
+      if (wasCodeUpdated) return
 
-  return { parse, sampleCode }
+      const wasLanguageUpdated = newLanguageId !== oldLanguageId
+      if (wasLanguageUpdated) {
+        const sampleCode = await loadLanguageSampleCode(newLanguageId)
+        code.value = sampleCode || ""
+      }
+    },
+    { immediate: true }
+  )
+
+  return code
 }
+
+function useDebounceTimeBasedOnCode(code: Ref<string>) {
+  const debounceTime = ref(0)
+
+  watchThrottled(
+    code,
+    () => {
+      debounceTime.value = getDebounceTimeForCode(code.value)
+    },
+    { throttle: 2000 }
+  )
+
+  return debounceTime
+}
+
+function getDebounceTimeForCode(code: string) {
+  const codeSize = code.length
+  for (const [maxCodeSize, debounceTime] of DEBOUNCE_TIME_THRESHOLDS) {
+    if (codeSize <= maxCodeSize) return debounceTime
+  }
+  return DEBOUNCE_TIME_THRESHOLDS[DEBOUNCE_TIME_THRESHOLDS.length - 1][0]
+}
+
+const DEBOUNCE_TIME_THRESHOLDS = [
+  [100, 150],
+  [300, 200],
+  [500, 250],
+  [1000, 300],
+  [0, 350],
+]

--- a/src/core/languages/index.ts
+++ b/src/core/languages/index.ts
@@ -4,8 +4,10 @@ const languages = {
   [javascript.id]: javascript,
 } as const
 
+export default languages
+
 export type Languages = typeof languages
 export type LanguageID = keyof Languages
 export type ParserName<L extends LanguageID> = keyof Languages[L]["parsers"]
 
-export default languages
+export { loadLanguageSampleCode } from "./utils"

--- a/src/core/languages/javascript/index.ts
+++ b/src/core/languages/javascript/index.ts
@@ -10,11 +10,4 @@ export default defineLanguage({
     [babelParser.name]: babelParser,
   },
   defaultParserName: babelParser.name,
-  sampleCode: [
-    "function greet(name) {",
-    '    console.log("Welcome, " + name + "!");',
-    "}",
-    "",
-    'greet("dear explorer");',
-  ],
 })

--- a/src/core/languages/javascript/sample.code.js
+++ b/src/core/languages/javascript/sample.code.js
@@ -1,0 +1,8 @@
+/**
+ * The demo code for the JavaScript language.
+ */
+function sayHello(name) {
+  console.log(`Hello, ${name}!`);
+}
+
+sayHello("World");

--- a/src/core/languages/utils.ts
+++ b/src/core/languages/utils.ts
@@ -1,0 +1,16 @@
+import type { LanguageID } from "@/core/languages"
+import languages from "@/core/languages"
+
+export async function loadLanguageSampleCode(
+  languageId: LanguageID
+): Promise<string | null> {
+  const language = languages[languageId]
+  try {
+    const module = await import(
+      `./${language.id}/sample.code.${language.fileExtension}`
+    )
+    return module.default
+  } catch (error) {
+    return null
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -34,11 +34,6 @@ export interface Language<
    * Name of the default parser from parsers.
    */
   readonly defaultParserName: ParserName
-
-  /**
-   * Code example written in this language (code or array of lines of code).
-   */
-  readonly sampleCode: string | string[]
 }
 
 export interface LanguageParser<Name extends Readonly<string>, ParseOptions> {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
   "extends": "@vue/tsconfig/tsconfig.web.json",
   "include": ["env.d.ts", "src/**/*", "package.json"],
-  "exclude": ["src/**/__tests__/*"],
+  "exclude": ["src/**/__tests__/*", "src/**/sample.code.*"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.vite-config.json
+++ b/tsconfig.vite-config.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.node.json",
-  "include": ["vite.config.*"],
+  "include": ["vite.config.*", "plugins/**/*"],
   "compilerOptions": {
     "composite": true,
     "types": ["node", "vitest", "vite/client"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,14 @@ import monacoEditorPlugin from "vite-plugin-monaco-editor"
 import nodePolyfills from "rollup-plugin-polyfill-node"
 import NodeModulesPolyfills from "@esbuild-plugins/node-modules-polyfill"
 import GlobalsPolyfills from "@esbuild-plugins/node-globals-polyfill"
+import languagesSampleCodePlugin from "./plugins/languagesSampleCodePlugin"
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     vue(),
     vueJsx(),
+    languagesSampleCodePlugin(),
     monacoEditorPlugin({
       publicBaseUrl: process.env.VITE_BASE_URL || "/",
     }),


### PR DESCRIPTION
*Change log:*
- Sample code for languages now can be created just in the `src/core/languages/$LanguageID$/sample.code.$LanguageFileExtension$` and it will be automatically imported
  - Rollup plugin `languagesSampleCodePlugin` created for implementing this
  - Code controlling logic moved to a separate `useCode` composable that on language change updates the code to sample code
- `debounceTime` is now dynamically calculated basing on the code length in the `useDebounceTimeBasedOnCode` composable